### PR TITLE
More logging, fix crash if token expired/invalid

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -17,16 +17,21 @@ wss.on('connection', async (socket, { url }) => {
     }
 
     try {
-        const { id } = verify(token, process.env.APERTURE_KEY), server = await fetchPortalFromId(id)
-        if(!id)
+        const { id } = verify(token, process.env.APERTURE_KEY)
+        if(!id) {
             log(`A client was rejected as the portal ID could not be found`)
-        if(!server)
-            log(`A client tried to connect to a stream which does not exists: ${id}`)
-        if(!id || !server) return socket.close()
+            return socket.close()
+        }
     } catch (error) {
         // I think we should log this for now as some people are experiencing issues
         // with this as their token gets expired, but shouldn't crash aperture now.
         console.error(`A client failed to authenticate`, error)
+        return socket.close()
+    }
+
+    const server = await fetchPortalFromId(id)
+    if(!server) {
+        log(`A client tried to connect to a stream which does not exists: ${id}`)
         return socket.close()
     }
 
@@ -53,19 +58,19 @@ const server = http.createServer((req, res) => {
             log(`An attempted stream from ${address} was rejected as the portal ID could not be found`)
             return res.end(null)
         }
+
+        res.connection.setTimeout(0)
+        log(`Stream with ID ${id} connected from ${address}`)
+
+        req.on('data', data =>
+            Array.from(wss.clients)
+                .filter(client => client['id'] === id)
+                .forEach(client => client.send(data))
+        )
     } catch (error) {
         console.error(`An attempted stream from ${address} failed in authentication`, error)
         return res.end(null)
     }
-
-    res.connection.setTimeout(0)
-    log(`Stream with ID ${id} connected from ${address}`)
-    
-    req.on('data', data =>
-        Array.from(wss.clients)
-            .filter(client => client['id'] === id)
-            .forEach(client => client.send(data))
-    )
 })
 
 server.listen(9000, () => log('Streaming Server running on :9000'))

--- a/src/index.js
+++ b/src/index.js
@@ -52,25 +52,27 @@ const server = http.createServer((req, res) => {
         return res.end(null)
     }
 
+    let id
+
     try {
-        const { id } = verify(token, process.env.APERTURE_KEY)
+        id = verify(token, process.env.APERTURE_KEY).id
         if(!id) {
             log(`An attempted stream from ${address} was rejected as the portal ID could not be found`)
             return res.end(null)
         }
-
-        res.connection.setTimeout(0)
-        log(`Stream with ID ${id} connected from ${address}`)
-
-        req.on('data', data =>
-            Array.from(wss.clients)
-                .filter(client => client['id'] === id)
-                .forEach(client => client.send(data))
-        )
     } catch (error) {
         console.error(`An attempted stream from ${address} failed in authentication`, error)
         return res.end(null)
     }
+
+    res.connection.setTimeout(0)
+    log(`Stream with ID ${id} connected from ${address}`)
+
+    req.on('data', data =>
+        Array.from(wss.clients)
+            .filter(client => client['id'] === id)
+            .forEach(client => client.send(data))
+    )
 })
 
 server.listen(9000, () => log('Streaming Server running on :9000'))

--- a/src/index.js
+++ b/src/index.js
@@ -18,17 +18,15 @@ wss.on('connection', async (socket, { url }) => {
 
     try {
         const { id } = verify(token, process.env.APERTURE_KEY), server = await fetchPortalFromId(id)
+        if(!id)
+            log(`A client was rejected as the portal ID could not be found`)
+        if(!server)
+            log(`A client tried to connect to a stream which does not exists: ${id}`)
+        if(!id || !server) return socket.close()
     } catch (error) {
         // I think we should log this for now as some people are experiencing issues
         // with this as their token gets expired, but shouldn't crash aperture now.
         console.error(`A client failed to authenticate`, error)
-    }
-    if(!id) {
-        log(`A client was rejected as the portal ID could not be found`)
-        return socket.close()
-    }
-    if(!server) {
-        log(`A client tried to connect to a stream which does not exists: ${id}`)
         return socket.close()
     }
 
@@ -51,11 +49,12 @@ const server = http.createServer((req, res) => {
 
     try {
         const { id } = verify(token, process.env.APERTURE_KEY)
+        if(!id) {
+            log(`An attempted stream from ${address} was rejected as the portal ID could not be found`)
+            return res.end(null)
+        }
     } catch (error) {
         console.error(`An attempted stream from ${address} failed in authentication`, error)
-    }
-    if(!id) {
-        log(`An attempted stream from ${address} was rejected as the portal ID could not be found`)
         return res.end(null)
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -11,19 +11,16 @@ console.log(require('fs').readFileSync('logo.txt', 'utf8'))
 const wss = new Server({ port: 9001 }, () => log('WebSocket Server running on :9001'))
 wss.on('connection', async (socket, { url }) => {
     const { t: token } = parse(url)
+
     if(!token) {
         log(`A client tried to connect but didn't provide a token`)
         return socket.close()
     }
 
-    let id
+    let payload
 
     try {
-        id = verify(token, process.env.APERTURE_KEY).id
-        if(!id) {
-            log(`A client was rejected as the portal ID could not be found`)
-            return socket.close()
-        }
+        payload = verify(token, process.env.APERTURE_KEY)
     } catch (error) {
         // I think we should log this for now as some people are experiencing issues
         // with this as their token gets expired, but shouldn't crash aperture now.
@@ -31,7 +28,14 @@ wss.on('connection', async (socket, { url }) => {
         return socket.close()
     }
 
-    const server = await fetchPortalFromId(id)
+    if(!payload.id) {
+        log(`A client was rejected as the portal ID could not be found`)
+        return socket.close()
+    }
+
+    const { id } = payload,
+            server = await fetchPortalFromId(id)
+
     if(!server) {
         log(`A client tried to connect to a stream which does not exists: ${id}`)
         return socket.close()
@@ -54,18 +58,21 @@ const server = http.createServer((req, res) => {
         return res.end(null)
     }
 
-    let id
+    let payload
 
     try {
-        id = verify(token, process.env.APERTURE_KEY).id
-        if(!id) {
-            log(`An attempted stream from ${address} was rejected as the portal ID could not be found`)
-            return res.end(null)
-        }
+        payload = verify(token, process.env.APERTURE_KEY)
     } catch (error) {
         console.error(`An attempted stream from ${address} failed in authentication`, error)
         return res.end(null)
     }
+
+    if(!payload.id) {
+        log(`An attempted stream from ${address} was rejected as the portal ID could not be found`)
+        return res.end(null)
+    }
+
+    const { id } = payload
 
     res.connection.setTimeout(0)
     log(`Stream with ID ${id} connected from ${address}`)

--- a/src/index.js
+++ b/src/index.js
@@ -16,8 +16,10 @@ wss.on('connection', async (socket, { url }) => {
         return socket.close()
     }
 
+    let id
+
     try {
-        const { id } = verify(token, process.env.APERTURE_KEY)
+        id = verify(token, process.env.APERTURE_KEY).id
         if(!id) {
             log(`A client was rejected as the portal ID could not be found`)
             return socket.close()


### PR DESCRIPTION
Will fix crashes related to JsonWebTokenError and TokenExpiredError.

Will also help in fixing issues (until errors are given to the client) as more logging was added.

---

console.error is used in authentication errors as some issues are coming from it, especially if the portal is started late.